### PR TITLE
Fix tag filtering when monitor_tag omitted

### DIFF
--- a/main.py
+++ b/main.py
@@ -197,10 +197,10 @@ def generate_tasks(tags: List[str], token: Optional[str]) -> List[MonitorTask]:
             if expected_token and token != expected_token:
                 continue
             monitor = cfg.get("monitor", {})
-            tag_match = monitor.get("monitor_tag")
+            tag_match = monitor.get("monitor_tag", [])
             if isinstance(tag_match, str):
                 tag_match = [t.strip() for t in tag_match.replace(",", " ").split()]
-            if not set(tags) & set(tag_match):
+            if tag_match and not set(tags) & set(tag_match):
                 continue
             for t in monitor.get("targets", []):
                 tasks.append(MonitorTask(


### PR DESCRIPTION
## Summary
- handle missing `monitor_tag` in task generation

## Testing
- `python -m py_compile main.py agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68454304ea3c8324b500afb81a95d100